### PR TITLE
Add core solver data structures and allocation wiring

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -8,6 +8,9 @@
 #include "imgui.h"
 #include "backends/imgui_impl_glfw.h"
 #include "backends/imgui_impl_opengl3.h"
+#include "solver/bc.hpp"
+#include "solver/grid.hpp"
+#include "solver/state.hpp"
 
 static std::string load_file(const char* path) {
     std::ifstream f(path);
@@ -64,6 +67,17 @@ int main() {
     ImGui_ImplOpenGL3_Init("#version 330");
 
     GLuint prog = build_program("shaders/quad.vert", "shaders/scalar.frag");
+
+    Grid grid;
+    grid.init(512, 256, 2.0, 1.0, 1);
+    State state;
+    state.u.allocate(grid.u_nx(), grid.ny, grid.u_pitch(), grid.ngx, grid.ngy);
+    state.v.allocate(grid.nx, grid.v_ny(), grid.v_pitch(), grid.ngx, grid.ngy);
+    state.p.allocate(grid.nx, grid.ny, grid.p_pitch(), grid.ngx, grid.ngy);
+    state.rhs.allocate(grid.nx, grid.ny, grid.p_pitch(), grid.ngx, grid.ngy);
+    state.tmp.allocate(grid.nx, grid.ny, grid.p_pitch(), grid.ngx, grid.ngy);
+    state.scalar.allocate(grid.nx, grid.ny, grid.p_pitch(), grid.ngx, grid.ngy);
+    printf("Grid: %d x %d (dx=%g, dy=%g)\n", grid.nx, grid.ny, grid.dx, grid.dy);
 
     float verts[] = {
         -1.0f, -1.0f, 0.0f, 0.0f,

--- a/src/solver/bc.cpp
+++ b/src/solver/bc.cpp
@@ -1,2 +1,20 @@
 #include "bc.hpp"
-// TODO: implement
+
+void apply_bc_u(const Grid& g, Field2D<double>& u, const BC& bc) {
+    (void)g;
+    (void)u;
+    (void)bc;
+}
+
+void apply_bc_v(const Grid& g, Field2D<double>& v, const BC& bc) {
+    (void)g;
+    (void)v;
+    (void)bc;
+}
+
+void apply_bc_p(const Grid& g, Field2D<double>& p, const BC& bc) {
+    (void)g;
+    (void)p;
+    (void)bc;
+}
+

--- a/src/solver/bc.hpp
+++ b/src/solver/bc.hpp
@@ -1,2 +1,20 @@
 #pragma once
-// Placeholder
+
+#include "grid.hpp"
+#include "field.hpp"
+
+enum class BCType { Wall, Moving, Inflow, Outflow, Periodic };
+
+struct BC {
+    BCType left = BCType::Wall;
+    BCType right = BCType::Wall;
+    BCType bottom = BCType::Wall;
+    BCType top = BCType::Wall;
+    double movingU = 1.0, movingV = 0.0;
+    double inflowUx = 1.0, inflowUy = 0.0;
+};
+
+void apply_bc_u(const Grid&, Field2D<double>&, const BC&);
+void apply_bc_v(const Grid&, Field2D<double>&, const BC&);
+void apply_bc_p(const Grid&, Field2D<double>&, const BC&);
+

--- a/src/solver/field.hpp
+++ b/src/solver/field.hpp
@@ -1,2 +1,74 @@
 #pragma once
-// Placeholder
+
+#include <cstdlib>
+#include <cstring>
+#include <new>
+#include <utility>
+
+// Simple aligned 2D field with ghost cells.
+template <typename T> struct Field2D {
+    int nx = 0, ny = 0, pitch = 0, ngx = 0, ngy = 0;
+    T *data = nullptr;
+
+    Field2D() = default;
+    ~Field2D() { free(); }
+
+    Field2D(const Field2D &) = delete;
+    Field2D &operator=(const Field2D &) = delete;
+
+    Field2D(Field2D &&other) noexcept { *this = std::move(other); }
+    Field2D &operator=(Field2D &&other) noexcept {
+        if (this != &other) {
+            free();
+            nx = other.nx;
+            ny = other.ny;
+            pitch = other.pitch;
+            ngx = other.ngx;
+            ngy = other.ngy;
+            data = other.data;
+            other.data = nullptr;
+            other.nx = other.ny = other.pitch = other.ngx = other.ngy = 0;
+        }
+        return *this;
+    }
+
+    void allocate(int NX, int NY, int pitch_, int ngx_, int ngy_) {
+        free();
+        nx = NX;
+        ny = NY;
+        pitch = pitch_;
+        ngx = ngx_;
+        ngy = ngy_;
+        size_t total = static_cast<size_t>(pitch) * (ny + 2 * ngy);
+#if defined(_MSC_VER)
+        data = static_cast<T *>(_aligned_malloc(total * sizeof(T), 64));
+        if (!data)
+            throw std::bad_alloc();
+#else
+        if (posix_memalign(reinterpret_cast<void **>(&data), 64,
+                           total * sizeof(T)) != 0)
+            data = nullptr;
+        if (!data)
+            throw std::bad_alloc();
+#endif
+        std::memset(data, 0, total * sizeof(T));
+    }
+
+    void free() {
+#if defined(_MSC_VER)
+        if (data)
+            _aligned_free(data);
+#else
+        if (data)
+            std::free(data);
+#endif
+        data = nullptr;
+        nx = ny = pitch = ngx = ngy = 0;
+    }
+
+    inline T &at_raw(int ii, int jj) { return data[jj * pitch + ii]; }
+    inline const T &at_raw(int ii, int jj) const {
+        return data[jj * pitch + ii];
+    }
+};
+

--- a/src/solver/grid.cpp
+++ b/src/solver/grid.cpp
@@ -1,2 +1,13 @@
 #include "grid.hpp"
-// TODO: implement
+
+void Grid::init(int Nx, int Ny, double Lx_, double Ly_, int ng) {
+    nx = Nx;
+    ny = Ny;
+    Lx = Lx_;
+    Ly = Ly_;
+    ngx = ng;
+    ngy = ng;
+    dx = Lx / static_cast<double>(nx);
+    dy = Ly / static_cast<double>(ny);
+}
+

--- a/src/solver/grid.hpp
+++ b/src/solver/grid.hpp
@@ -1,2 +1,25 @@
 #pragma once
-// Placeholder
+
+struct Grid {
+    int nx = 0, ny = 0;    // cells in x/y
+    int ngx = 1, ngy = 1;  // ghost layers
+    double Lx = 1.0, Ly = 1.0;  // domain size
+    double dx = 0.0, dy = 0.0;  // cell size
+
+    void init(int Nx, int Ny, double Lx_, double Ly_, int ng = 1);
+
+    // pressure (cell centers)
+    inline int p_pitch() const { return nx + 2 * ngx; }
+    inline int p_idx(int i, int j) const { return (j + ngy) * p_pitch() + (i + ngx); }
+
+    // u faces (x-directed)
+    inline int u_nx() const { return nx + 1; }
+    inline int u_pitch() const { return u_nx() + 2 * ngx; }
+    inline int u_idx(int i, int j) const { return (j + ngy) * u_pitch() + (i + ngx); }
+
+    // v faces (y-directed)
+    inline int v_ny() const { return ny + 1; }
+    inline int v_pitch() const { return nx + 2 * ngx; }
+    inline int v_idx(int i, int j) const { return (j + ngy) * v_pitch() + (i + ngx); }
+};
+

--- a/src/solver/state.hpp
+++ b/src/solver/state.hpp
@@ -1,2 +1,10 @@
 #pragma once
-// Placeholder
+
+#include "field.hpp"
+
+struct State {
+    Field2D<double> u, v, p;    // primary fields
+    Field2D<double> rhs, tmp;   // work buffers
+    Field2D<float> scalar;      // visualization buffer
+};
+


### PR DESCRIPTION
## Summary
- Implement MAC grid descriptor with index helpers and spacing computation.
- Add aligned 2D field container for solver data with ghost-cell support.
- Define simulation state and boundary-condition stubs.
- Allocate solver fields in `main.cpp` and print grid info.

## Testing
- `cmake -S . -B build -DCMAKE_CXX_COMPILER=g++` *(pass)*
- `cmake --build build -j` *(fail: OpenGL/gl3.h not found)*

------
https://chatgpt.com/codex/tasks/task_e_689c150311e083248d2d03b4abe8af2a