### PR TITLE
Add simulations tab with jet plume preset

### DIFF
--- a/src/gui/gui.hpp
+++ b/src/gui/gui.hpp
@@ -11,15 +11,20 @@
 
 class Gui {
   public:
-    enum class Field { U, V, Speed, Pressure };
+    enum class Field { U, V, Speed, Pressure, Vorticity };
+
+    enum class Preset { JetPlume, LidDrivenCavity, PeriodicShear };
 
     double Re = 1000.0;
     double CFL = 0.5;
     double dt = 0.001;  // dt override
     bool running = true;
     bool step = false;
-    bool reset = false;
+    bool reset = false;          // generic reset
+    bool apply_preset = false;   // trigger to apply chosen preset
+    bool reset_run = false;      // reset fields and start running
     Field field = Field::Speed;
+    int preset = static_cast<int>(Preset::JetPlume);
     BC bc;             // boundary condition settings
     double Ly = 1.0;   // domain height for jet sliders
 

--- a/src/solver/bc.hpp
+++ b/src/solver/bc.hpp
@@ -20,6 +20,10 @@ struct BC {
     // Jet inflow parameters (used on left when type==Inflow)
     double jet_center = 0.5; // y0
     double jet_width = 0.2;  // w
+    double jet_thickness = 0.02; // smoothing thickness delta
+    double jet_eps = 0.03;       // perturbation amplitude
+    int jet_k = 8;               // perturbation wavenumber
+    double jet_phase = 0.0;      // perturbation phase
 };
 
 void apply_bc_u(const Grid&, Field2D<double>&, const BC&);


### PR DESCRIPTION
## Summary
- Add configurable simulations tab with presets for Jet Plume, Lid-Driven Cavity, and Periodic Shear
- Implement smooth jet inflow with perturbations and vorticity visualization option
- Handle preset application and reset logic in main loop with dark blue background

## Testing
- `cmake -S . -B build -DCMAKE_CXX_COMPILER=$(brew --prefix llvm)/bin/clang++ -DCMAKE_PREFIX_PATH=$(brew --prefix glfw) -DOpenMP_CXX_FLAGS="-fopenmp" -DOpenMP_CXX_LIB_NAMES="omp" -DOpenMP_omp_LIBRARY=$(brew --prefix llvm)/lib/libomp.dylib` *(fails: command not found: brew)*


------
https://chatgpt.com/codex/tasks/task_e_689c3bc292a88324baabdf6a274d33eb