### PR TITLE
Fix NaNs and enforce inflow boundaries

### DIFF
--- a/src/gui/gui.hpp
+++ b/src/gui/gui.hpp
@@ -27,6 +27,7 @@ class Gui {
     int preset = static_cast<int>(Preset::JetPlume);
     BC bc;             // boundary condition settings
     double Ly = 1.0;   // domain height for jet sliders
+    bool inflow_inactive = false;
 
     bool init(GLFWwindow *window);
     void begin_frame();

--- a/src/solver/pressure.hpp
+++ b/src/solver/pressure.hpp
@@ -22,9 +22,13 @@ class PressureSolver {
     double solve(Field2D<double> &p, const Field2D<double> &rhs,
                  const PressureParams &params);
 
+    double last_residual() const { return last_residual_; }
+
   private:
     const Grid &g;
     Field2D<double> r, z, s, Ap; // PCG work buffers
+    double last_residual_ = 0.0;
+    bool warned_nan_ = false;
 
     void apply_laplacian(const Field2D<double> &in,
                          Field2D<double> &out) const;

--- a/src/solver/time_integrator.cpp
+++ b/src/solver/time_integrator.cpp
@@ -1,6 +1,9 @@
 #include "time_integrator.hpp"
 
+#include <algorithm>
+#include <cmath>
 #include <cstring>
+#include <limits>
 
 TimeIntegrator::TimeIntegrator(const Grid &grid) : g(grid) {
     // allocate work arrays matching velocity layouts
@@ -8,6 +11,16 @@ TimeIntegrator::TimeIntegrator(const Grid &grid) : g(grid) {
     dv_dt.allocate(g.nx, g.v_ny(), g.v_pitch(), g.ngx, g.ngy);
     u1.allocate(g.u_nx(), g.ny, g.u_pitch(), g.ngx, g.ngy);
     v1.allocate(g.nx, g.v_ny(), g.v_pitch(), g.ngx, g.ngy);
+    clear_work();
+}
+
+void TimeIntegrator::clear_work() {
+    size_t sz_u = static_cast<size_t>(du_dt.pitch) * (du_dt.ny + 2 * du_dt.ngy);
+    size_t sz_v = static_cast<size_t>(dv_dt.pitch) * (dv_dt.ny + 2 * dv_dt.ngy);
+    std::memset(du_dt.data, 0, sz_u * sizeof(double));
+    std::memset(dv_dt.data, 0, sz_v * sizeof(double));
+    std::memset(u1.data, 0, sz_u * sizeof(double));
+    std::memset(v1.data, 0, sz_v * sizeof(double));
 }
 
 double TimeIntegrator::step(State &s, const BC &bc, double Re, double CFL,
@@ -18,8 +31,14 @@ double TimeIntegrator::step(State &s, const BC &bc, double Re, double CFL,
     apply_bc_v(g, s.v, bc);
     apply_bc_p(g, s.p, bc);
 
-    double dt = dt_override > 0.0 ? dt_override
-                                  : compute_cfl(g, s.u, s.v, Re, CFL);
+    double dt_cfl = compute_cfl(g, s.u, s.v, Re, CFL);
+    double dt = dt_cfl;
+    if (dt_override > 0.0)
+        dt = std::min(dt_cfl, dt_override);
+    double diff_limit = 0.5 * Re * std::min(g.dx * g.dx, g.dy * g.dy);
+    if (!std::isfinite(dt) || dt <= 0.0)
+        dt = std::min(1e-3, diff_limit);
+    dt = std::clamp(dt, 1e-12, (dt_override > 0.0) ? dt_override : dt);
 
     size_t sz_u = static_cast<size_t>(du_dt.pitch) * (du_dt.ny + 2 * du_dt.ngy);
     size_t sz_v = static_cast<size_t>(dv_dt.pitch) * (dv_dt.ny + 2 * dv_dt.ngy);
@@ -86,6 +105,28 @@ double TimeIntegrator::step(State &s, const BC &bc, double Re, double CFL,
     apply_bc_u(g, s.u, bc);
     apply_bc_v(g, s.v, bc);
 
+    // Check for NaNs before projection
+    size_t total_u = static_cast<size_t>(g.u_nx()) * g.ny;
+    size_t total_v = static_cast<size_t>(g.nx) * g.v_ny();
+    size_t count_u = 0, count_v = 0;
+#pragma omp parallel for collapse(2) reduction(+ : count_u)
+    for (int j = 0; j < g.ny; ++j)
+        for (int i = 0; i < g.u_nx(); ++i) {
+            int ii = i + g.ngx, jj = j + g.ngy;
+            if (std::isfinite(s.u.at_raw(ii, jj))) ++count_u;
+        }
+#pragma omp parallel for collapse(2) reduction(+ : count_v)
+    for (int j = 0; j < g.v_ny(); ++j)
+        for (int i = 0; i < g.nx; ++i) {
+            int ii = i + g.ngx, jj = j + g.ngy;
+            if (std::isfinite(s.v.at_raw(ii, jj))) ++count_v;
+        }
+    if (count_u < total_u || count_v < total_v) {
+        std::fprintf(stderr, "NaN detected -> skipping projection this step\n");
+        pressure_residual = std::numeric_limits<double>::quiet_NaN();
+        return dt;
+    }
+
     // Projection
     divergence(g, s.u, s.v, s.rhs);
 #pragma omp parallel for collapse(2)
@@ -93,12 +134,15 @@ double TimeIntegrator::step(State &s, const BC &bc, double Re, double CFL,
         for (int i = 0; i < g.nx; ++i) {
             int ii = i + g.ngx;
             int jj = j + g.ngy;
-            s.rhs.at_raw(ii, jj) *= 1.0 / dt;
+            double val = s.rhs.at_raw(ii, jj) * (1.0 / dt);
+            s.rhs.at_raw(ii, jj) = std::isfinite(val) ? val : 0.0;
         }
     }
 
     apply_bc_p(g, s.p, bc);
+    s.p.at_raw(g.ngx, g.ngy) = 0.0; // pin pressure
     pressure_residual = pressure.solve(s.p, s.rhs, pp);
+    s.p.at_raw(g.ngx, g.ngy) = 0.0;
     apply_bc_p(g, s.p, bc);
     subtract_grad_p(g, s.u, s.v, s.p, dt);
     apply_bc_u(g, s.u, bc);

--- a/src/solver/time_integrator.hpp
+++ b/src/solver/time_integrator.hpp
@@ -17,6 +17,9 @@ struct TimeIntegrator {
 
     explicit TimeIntegrator(const Grid &grid);
 
+    // Zero out all work arrays
+    void clear_work();
+
     // Advance one step. Returns chosen dt. pressure_residual is output.
     double step(State &s, const BC &bc, double Re, double CFL,
                 PressureSolver &pressure, const PressureParams &pp,

--- a/src/ui.cpp
+++ b/src/ui.cpp
@@ -1,2 +1,2 @@
 #include "ui.hpp"
-// TODO: implement UI
+// UI moved to gui/; this file remains as a stub.

--- a/src/ui.hpp
+++ b/src/ui.hpp
@@ -1,2 +1,2 @@
 #pragma once
-// Placeholder for UI interface
+// Legacy placeholder: GUI is implemented in gui/ subdirectory.

--- a/src/viz.cpp
+++ b/src/viz.cpp
@@ -1,2 +1,52 @@
 #include "viz.hpp"
-// TODO: implement visualization
+
+#include <algorithm>
+#include <cmath>
+
+void compute_scalar(const Grid &g, const State &s, ScalarField field,
+                    std::vector<double> &out, double &vmin, double &vmax) {
+    int nx = g.nx;
+    int ny = g.ny;
+    out.resize(static_cast<size_t>(nx) * ny);
+    vmin = 1e30;
+    vmax = -1e30;
+    for (int j = 0; j < ny; ++j) {
+        for (int i = 0; i < nx; ++i) {
+            int ii = i + g.ngx;
+            int jj = j + g.ngy;
+            double val = 0.0;
+            switch (field) {
+            case ScalarField::U:
+                val = 0.5 * (s.u.at_raw(ii, jj) + s.u.at_raw(ii + 1, jj));
+                break;
+            case ScalarField::V:
+                val = 0.5 * (s.v.at_raw(ii, jj) + s.v.at_raw(ii, jj + 1));
+                break;
+            case ScalarField::Speed: {
+                double uc = 0.5 * (s.u.at_raw(ii, jj) + s.u.at_raw(ii + 1, jj));
+                double vc = 0.5 * (s.v.at_raw(ii, jj) + s.v.at_raw(ii, jj + 1));
+                val = std::sqrt(uc * uc + vc * vc);
+                break;
+            }
+            case ScalarField::Pressure:
+                val = s.p.at_raw(ii, jj);
+                break;
+            case ScalarField::Vorticity: {
+                double dv_dx = (s.v.at_raw(ii + 1, jj) - s.v.at_raw(ii - 1, jj)) /
+                               (2.0 * g.dx);
+                double du_dy = (s.u.at_raw(ii, jj + 1) - s.u.at_raw(ii, jj - 1)) /
+                               (2.0 * g.dy);
+                val = dv_dx - du_dy;
+                break;
+            }
+            }
+            if (!std::isfinite(val))
+                val = 0.0;
+            out[i + j * nx] = val;
+            vmin = std::min(vmin, val);
+            vmax = std::max(vmax, val);
+        }
+    }
+    double span = std::max(1e-6, vmax - vmin);
+    vmax = vmin + span;
+}

--- a/src/viz.hpp
+++ b/src/viz.hpp
@@ -1,3 +1,12 @@
 #pragma once
 
-// Placeholder for future visualization interface
+#include <vector>
+
+#include "solver/grid.hpp"
+#include "solver/state.hpp"
+
+enum class ScalarField { U, V, Speed, Pressure, Vorticity };
+
+// Compute a scalar field for visualization. Returns min/max in vmin/vmax.
+void compute_scalar(const Grid &g, const State &s, ScalarField field,
+                    std::vector<double> &out, double &vmin, double &vmax);


### PR DESCRIPTION
## Summary
- Clear all solver fields on start/reset and clamp timestep for stability
- Clamp jet slot width, zero normal v at inflow, and re-apply inflow after projection
- Harden pressure solver and projection pipeline against non-finite values
- Sanitize visualization ranges and expose inflow status in HUD

## Testing
- ⚠️ `brew install llvm glfw` (missing: command not found)
- ⚠️ `cmake -S . -B build -DCMAKE_CXX_COMPILER=$(brew --prefix llvm)/bin/clang++ -DCMAKE_PREFIX_PATH=$(brew --prefix glfw) -DOpenMP_CXX_FLAGS="-fopenmp" -DOpenMP_CXX_LIB_NAMES="omp" -DOpenMP_omp_LIBRARY=$(brew --prefix llvm)/lib/libomp.dylib` (failed: command not found: brew)
- ⚠️ `cmake --build build -j` (failed: No rule to make target 'Makefile')
- ⚠️ `./build/cfd2d_gui --no-gui` (failed: No such file or directory)


------
https://chatgpt.com/codex/tasks/task_e_689c4276abe08324aabf4f51429d69b2